### PR TITLE
Switches to publicly-available "rouge" gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # the following line to use "https"
 source 'http://rubygems.org'
 
-gem "rouge", :path => "/Users/adam-home/lib/rouge"
+gem "rouge", "0.3.9"
 gem "middleman"
 gem "middleman-syntax"
 gem "redcarpet", "2.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-PATH
-  remote: /Users/adam-home/lib/rouge
-  specs:
-    rouge (0.3.9)
-      thor
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -78,6 +72,8 @@ GEM
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
     redcarpet (2.3.0)
+    rouge (0.3.9)
+      thor
     sass (3.2.9)
     sprockets (2.10.0)
       hike (~> 1.2)
@@ -105,4 +101,4 @@ DEPENDENCIES
   middleman-clementine
   middleman-syntax
   redcarpet (= 2.3.0)
-  rouge!
+  rouge (= 0.3.9)


### PR DESCRIPTION
Gemfile was previously pointed to a local path for "rouge".  Instead use the public gem.  (Needed this to be able to test locally.)

If you're using local "rouge" modifications, it'd be nice to get them pushed upstream.  If you're just using an as-yet-unreleased gem, maybe [:github and/or :ref](http://bundler.io/v1.3/git.html) would be a better alternative.