### PR TITLE
Fixed zero-contributor code

### DIFF
--- a/source/layouts/doc.erb
+++ b/source/layouts/doc.erb
@@ -16,7 +16,7 @@
     <%= articles.get(data.page).contributors[0][0] %>, and updated by
     <a href="https://github.com/adambard/learnxinyminutes-docs/blame/master/<%= current_page.path.split('/')[1] %>.markdown">
     <%= articles.get(data.page).contributor_count %>
-    <%= if articles.get(data.page).contributor_count <= 1 then "contributor" else "contributors" end %>
+    <%= if articles.get(data.page).contributor_count == 1 then "contributor" else "contributors" end %>
   </a>
     </p>
 


### PR DESCRIPTION
At present, the page will say "0 contributor" if there have been zero non-original-author contributors, when it should say "0 contributors". I have fixed this.

It may be worth looking at making it say something other than "and updated by 0 contributors" if it hasn't been updated by any contributors. In the mean time, however, "0 contributors" is a lot better than "0 contributor". 

JH
