### PR TITLE
Better czech translation

### DIFF
--- a/data/i18n.yaml
+++ b/data/i18n.yaml
@@ -87,7 +87,7 @@ id_id:
   contributor: "Awalnya merupakan kontribusi %s, dan telah diperbaharui oleh <a href=\"%s\">%d contributor(s)</a>."
 
 cs_cz:
-  title: Nauč se X v Y minutách
+  title: Nauč se X za Y minut
   where: Kde X=
   getCode: "Získej kód:"
   share: Sdílej stránku


### PR DESCRIPTION
We have discussed the translations and thought it is better to say “za Y minut” then “v Y minutách” in Czech.

See https://twitter.com/voy/status/720143290239164417
