### PR TITLE
Fix code being wrapped incorrectly

### DIFF
--- a/source/css/screen.css.sass
+++ b/source/css/screen.css.sass
@@ -19,7 +19,7 @@ li+li
   margin-top: 0
 
 .container
-  max-width: 840px
+  max-width: 60em 
   margin: 0px auto
 
   @media all and (max-width: 880px)


### PR DESCRIPTION
This should prevent code from being wrapped when displayed on the site. I'm not sure if it's just my font choices, but that ideally wouldn't affect the code wrapping. (Anyone else have this problem other than me?)

![Screenshot of Before](http://imgur.com/o9DdRQj.jpg)
![Screenshot of After](http://imgur.com/rh13psR.jpg)

I've tested this in chromium and firefox by editing the css in-browser, but I wasn't able to test the actual changes to the sass file.
