### PR TITLE
Attempt to fix issue #44

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,4 +1,7 @@
-<!DOCTYPE html>
+<%
+	_lang = data.page.lang || 'en-us'
+%>
+<!DOCTYPE html lang="<%= _lang %>" xml:lang="<%= _lang %>" xmlns="http://www.w3.org/1999/xhtml">
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
@@ -6,6 +9,7 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="Content-Language" content="<%= _lang %>">
         <!-- Use title if it's in the page YAML frontmatter -->
         <title><%= if data.page.language then "Learn " + data.page.language + " in Y Minutes" else "Learn X in Y Minutes: Scenic Programming Language Tours" end %></title>
         <meta name="description" content="">


### PR DESCRIPTION
Adding lang attributes to force Chrome to recognise the language correctly.
Allowing `data.page.lang` frontmatter to override the default ('en-us').