### PR TITLE
Improve styling of code blocks

### DIFF
--- a/source/css/screen.css.sass
+++ b/source/css/screen.css.sass
@@ -19,7 +19,7 @@ li+li
   margin-top: 0
 
 .container
-  max-width: 60em 
+  max-width: 60em
   margin: 0px auto
 
   @media all and (max-width: 880px)
@@ -42,7 +42,8 @@ li+li
 // Modifications to highlighting
 .highlight
   background: #eee
-  padding: 18pt
+  padding: 0 18pt
+  margin-top: $vs
   overflow-x: auto
 
   &.c
@@ -92,7 +93,7 @@ td.lang a
 // Responsive table
 
 @media all and (max-width: 620px)
-  
+
   tr
     display: block
     border-bottom: 3px solid #eee


### PR DESCRIPTION
Before:

<img width="300" alt="screen shot 2017-12-16 at 11 36 26 pm" src="https://user-images.githubusercontent.com/129149/34074958-f791f384-e2b9-11e7-8822-397887559b14.png">

After:

<img width="300" alt="screen shot 2017-12-16 at 11 36 09 pm" src="https://user-images.githubusercontent.com/129149/34074959-f9f66434-e2b9-11e7-95a0-d8bb56445414.png">
