### PR TITLE
Fix twitter share link

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -24,7 +24,7 @@ end
 helpers do
   def twitter_share_url(url, doc)
       full_url = "https://learnxinyminutes.com" + (url || "")
-      text = "Learn X in Y minutes, where X=" + (doc || "")
+      text = (doc || "")
       qs = URI.encode_www_form("url" => full_url, "text" => text)
       "https://twitter.com/intent/tweet?#{qs}"
   end

--- a/source/layouts/doc.erb
+++ b/source/layouts/doc.erb
@@ -1,7 +1,7 @@
 <% wrap_layout :layout do %>
   <div class="share">
     <span class="sharemsg">
-      <a href="<%= twitter_share_url(current_page.url, articles.get(data.page).name) %>">
+      <a href="<%= twitter_share_url(current_page.url, i18n.t(data, 'title') + ", " + (i18n.t(data, 'where'))[0].downcase + (i18n.t(data, 'where'))[1..-1] + "" + articles.get(data.page).name) %>">
         <%= i18n.t(data, 'share') %>
       </a></span>
 


### PR DESCRIPTION
Fixed twitter sharing link to display correct text in case sharing a translated page. See screenshots below -

![english](https://user-images.githubusercontent.com/11337492/47527280-d2b17b00-d8bf-11e8-9c41-5c041b00e71f.png)

![german](https://user-images.githubusercontent.com/11337492/47527281-d2b17b00-d8bf-11e8-9217-4c5ece68fc44.png)

![italian](https://user-images.githubusercontent.com/11337492/47527282-d34a1180-d8bf-11e8-821c-b95598235f2a.png)

![spanish](https://user-images.githubusercontent.com/11337492/47527283-d34a1180-d8bf-11e8-8c1c-a76fdb0f3a90.png)
