### PR TITLE
Improve styling of code blocks

### DIFF
--- a/source/css/screen.css.sass
+++ b/source/css/screen.css.sass
@@ -67,7 +67,6 @@ li+li
     font-weight: 700
   .n
     color: #333
-  margin: 0
 
 table
   margin-top: $vs


### PR DESCRIPTION
https://github.com/adambard/learnxinyminutes-site/commit/072c82a4ead7e64988a8e9fffb9cd4be01218525#diff-0cb99fc4e97a81397f7df2eaead8b1f7R46

Line 46 of the only changed file in this commit was intended to improve the styling of the code blocks, but it does not work because of there is a `margin: 0` several lines later overriding this new margin setting. This leads to the ugly distance between code blocks and there previous element. 

Removing this line fixes the problem and as far as I know does not have any side effect.