### PR TITLE
Updated CSS Rule for highlighted text

### DIFF
--- a/source/css/dark.css.scss
+++ b/source/css/dark.css.scss
@@ -30,6 +30,7 @@ html.dark {
       border-bottom: 2px solid lighten($bg, 25%);
       &:hover, &.selected{
         background: $highlight;
+        color: $text;
       }
   }
 


### PR DESCRIPTION
Hi,
I updated the CSS rule for highlighted text, to make the label readable in dark mode.

Before:
![image](https://user-images.githubusercontent.com/804939/66298933-d8e31080-e8f2-11e9-904d-f1a0985244fc.png)

After:
![Learn X in Y Minutes: Scenic Programming Language Tours 2019-10-07 11-09-07](https://user-images.githubusercontent.com/804939/66298956-e26c7880-e8f2-11e9-83d7-37036bde8340.png)

Regards :) 