### PR TITLE
Better translation for Russian and Czech theme names

### DIFF
--- a/data/i18n.yaml
+++ b/data/i18n.yaml
@@ -125,7 +125,7 @@ cs_cz:
   getCode: "Získej kód:"
   share: Sdílej stránku
   selectTheme: "Vyberte téma:"
-  lightTheme: lehké
+  lightTheme: světlé
   darkTheme: tmavé
   suggestions: "Máš připomínku, nebo si našel chybu? <a href=\"%s\">Otevři tiket</a> v Github repozitáři, nebo <a href=\"%s\">pošli rovnou</a> svojí úpravu!"
   contributor: "Autor původní verze je %s a na úpravách se podílelo <a href=\"%s\">%d lidí</a>."
@@ -147,8 +147,8 @@ ru_ru:
   getCode: "Получить исходный код:"
   share: Поделиться страницей
   selectTheme: "Выберите тему:"
-  lightTheme: легкая
-  darkTheme: темная
+  lightTheme: светлая
+  darkTheme: тёмная
   suggestions: "Хотите предложить свой перевод? Может быть, улучшение перевода? <a href=\"%s\">Откройте Issue</a> в репозитории Github или сделайте <a href=\"%s\">pull request</a> сами!"
   contributor: "Первоначально предоставлено автором %s, и обновлено <a href=\"%s\">%d автором (-ами)</a>."
 


### PR DESCRIPTION
"легкая" means lightweight in Russian instead of light-colored, so "светлая" is the correct word in Russian. It is the same story for Czech.