### PR TITLE
Better translation for German and French theme names

### DIFF
--- a/data/i18n.yaml
+++ b/data/i18n.yaml
@@ -15,8 +15,8 @@ fr_fr:
   getCode: "Récupérer le code :"
   share: Partager cette page
   selectTheme: "Sélectionne un thème:"
-  lightTheme: lumière
-  darkTheme: foncé
+  lightTheme: clair
+  darkTheme: sombre
   suggestions: "Vous avez une suggestion ? Peut-être une correction ? <a href=\"%s\">Ouvrez un ticket</a> sur Github, ou faites vous-même une <a href=\"%s\">pull request</a> !"
   contributor: "Version originale par %s, mis à jour par <a href=\"%s\">%d contributeur(s)</a>."
 
@@ -81,8 +81,8 @@ de_de:
   getCode: "Lade den Code herunter:"
   share: Teile diese Seite mit anderen
   selectTheme: "Thema wählen:"
-  lightTheme: licht
-  darkTheme: dunkles
+  lightTheme: hell
+  darkTheme: dunkel
   suggestions: "Du hast einen Verbesserungsvorschlag oder einen Fehler gefunden? <a href=\"%s\">Erstelle ein Ticket</a> im offiziellen Github Repo, oder du erstellst einfach gleich einen <a href=\"%s\">pull request</a>!"
   contributor: "Originalversion von %s, mit Updates von <a href=\"%s\">%d contributor(s)</a>."
 


### PR DESCRIPTION
"licht" means "light source", "dunkles" means "something dark", changed
it to "hell" und "dunkel", the correct translation. Same for French.