### PR TITLE
Fix text selection color in dark mode

### DIFF
--- a/source/css/dark.css.scss
+++ b/source/css/dark.css.scss
@@ -18,6 +18,10 @@ html.dark {
     color: $text;
   }
 
+  ::selection {
+      color: black;
+  }
+    
   a {
       color: $highlight;
   }


### PR DESCRIPTION
Currently when text is selected it is unreadable

![image](https://user-images.githubusercontent.com/6676843/100029658-c3170000-2dbf-11eb-82f5-556341cd4720.png)
