### PR TITLE
Add a new section for 'Frameworks and Libraries'

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -262,7 +262,8 @@ class ArticleManager
   def get_article(page)
     name = page.fetch("name",
       page.fetch("tool",
-        page.fetch("language", nil)))
+        page.fetch("framework",
+          page.fetch("language", nil))))
 
     language = page.fetch("lang", "en")
 

--- a/config.rb
+++ b/config.rb
@@ -145,6 +145,7 @@ class Article
 
       @name_key = case @category
         when "language" then "language"
+        when "framework" then "framework"
         when "tool" then "tool"
         else "name"
       end
@@ -219,7 +220,7 @@ class Article
 end
 
 class ArticleManager
-  attr_accessor :articles, :articles_by_name, :articles_by_category_en
+  attr_accessor :articles, :articles_by_name, :articles_by_category_en, :categories_en
   def initialize(sitemap)
     @articles = sitemap.resources.select{|r|
       not IGNORED.include?(r.path)
@@ -233,6 +234,8 @@ class ArticleManager
 
     @articles_by_category_en = @articles_en.group_by{|r| r.category}
     @articles_by_name_en = @articles_en.group_by(&:name)
+
+    @categories_en = ["Algorithms & Data Structures", "language", "framework", "tool"] | articles_by_category_en.keys
 
     #@articles.each{|a| puts a.url + ": " + a.language + " (" + a.category + ")"}
     @articles.select{|a| a.language != "en" and not a.name.nil?}.each{|a|
@@ -250,6 +253,7 @@ class ArticleManager
   def get_category_display_name(c)
     case c
       when "language" then "Languages"
+      when "framework" then "Frameworks"
       when "tool" then "Tools"
       else c
     end

--- a/config.rb
+++ b/config.rb
@@ -253,7 +253,7 @@ class ArticleManager
   def get_category_display_name(c)
     case c
       when "language" then "Languages"
-      when "framework" then "Frameworks"
+      when "framework" then "Frameworks and Libraries"
       when "tool" then "Tools"
       else c
     end

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -19,7 +19,7 @@ layout: home
 %p Take a whirlwind tour of your next favorite language. Community-driven!
 
 // Sorry
-- articles.articles_by_category_en.keys.sort.each do |c|
+- articles.categories_en.each do |c|
   - if c != "meta"
     %table
       %tr


### PR DESCRIPTION
Add a "Frameworks and Libraries" section. This will help the community find docs on frameworks and libraries, and also encourage the community to document more frameworks. I am moving existing frameworks over to the "Frameworks and Libraries" section in [another PR](https://github.com/adambard/learnxinyminutes-docs/pull/4136). Eventually, I hope many more frameworks like React, Express, Django, etc. will go here. 

This is a small, but important change. I think it will really help direct the community to document more frameworks on learn x in y, which would be very helpful to developers.

Before:
![before](https://user-images.githubusercontent.com/74446843/110576059-e4a0bb00-8114-11eb-870e-07f3427d5c1a.png)

After:
![after](https://user-images.githubusercontent.com/74446843/110576067-e79bab80-8114-11eb-92e3-e2535733646b.png)

