### PR TITLE
Fix i18n for th_th on lightTheme

### DIFF
--- a/data/i18n.yaml
+++ b/data/i18n.yaml
@@ -169,7 +169,7 @@ th_th:
   getCode: "ดาวน์โหลดโค๊ด:"
   share: แชร์หน้านี้
   selectTheme: "เลือกธีม:"
-  lightTheme: เบา
+  lightTheme: สว่าง
   darkTheme: มืด
   suggestions: "มีคำแนะนำหรือข้อควรปรับปรุง <a href=\"%s\">แจ้งทีมงาน</a> บน Github Repo, หรือส่ง <a href=\"%s\">pull request</a> ในส่วนที่แก้ไข!"
   contributor: "พัฒนาโดย %s, และอัพเดทโดย <a href=\"%s\">%d ผู้ร่วมแก้ไข(s)</a>."


### PR DESCRIPTION
I've found that "lightTheme" in Thai are not correct 

- `เบา` in Thai are light weight 
- `สว่าง` in Thai are light theme
