### PR TITLE
Change fallback font in code section to sans-serif

### DIFF
--- a/source/css/normalize.css
+++ b/source/css/normalize.css
@@ -208,7 +208,7 @@ code,
 kbd,
 pre,
 samp {
-    font-family: monospace, serif;
+    font-family: monospace, sans-serif;
     _font-family: 'courier new', monospace;
     font-size: 1em;
 }


### PR DESCRIPTION
If there is no monospace glyph available for CJK letters, they will be rendered using a fallback font. Given that most monospace fonts used in programming are sans-serif (just my opinion 😉), it is preferable to use a sans-serif fallback font for consistency and readability.

Fonts
Monospace: Hack
Serif: Noto Serif KR
Sans-serif: Noto Sans KR

Before:
![image](https://github.com/adambard/learnxinyminutes-site/assets/62266626/d12d3266-92b1-4f0a-82f1-773d0e7bb534)

After:
![image](https://github.com/adambard/learnxinyminutes-site/assets/62266626/4a82b44a-04d2-46e9-92a0-113d9cd9bf79)
