### PR TITLE
Fix code block padding

### DIFF
--- a/source/css/screen.css.sass
+++ b/source/css/screen.css.sass
@@ -40,7 +40,7 @@ li+li
 
 #doc
   font-size: 14pt
-  .highlight
+  div.highlight
     font-family: "Ubuntu Mono", monospace
     line-height: 18pt
     display: block
@@ -53,7 +53,7 @@ li+li
     color: #777
 
 // Modifications to highlighting
-.highlight
+div.highlight
   background: #eee
   padding: 0 18pt
   margin-top: $vs


### PR DESCRIPTION
#114 switched from Pygments to [rouge](https://github.com/rouge-ruby/rouge), which changed the structure of the generated HTML for code blocks from

```html
<div class="highlight">
    <pre>
    </pre>
</div>
```

to

```html
<div class="highlight">
    <pre class="highlight python">
    </pre>
</div>
```

So the `.highlight` class is being applied twice and there's double the padding.