### PR TITLE
Add Hebrew translation of the i18n strings

### DIFF
--- a/data/i18n.yaml
+++ b/data/i18n.yaml
@@ -255,3 +255,17 @@ be:
   contributor-other: "Першапачатковы аўтар %s, абноўлена <a href=\"%s\">%d аўтарамі</a>."
   translatedBy-one: "Перакладзена:"
   translatedBy-other: "Перакладзена:"
+
+he:
+  title: "למדו X ב־Y דקות"
+  where: "כאשר X="
+  getCode: "הורידו את קובץ המקור:"
+  share: "שתפו את העמוד"
+  selectTheme: "בחרו ערכת נושא:"
+  lightTheme: "בהירה"
+  darkTheme: "כהה"
+  suggestions: "יש לכן·ם הצעה? אולי תיקון? <a href=\"%s\">פתחו אישיו</a> בריפו בגיטהאב, או צרו <a href=\"%s\">פול ריקווסט</a> בעצמכן·ם!"
+  contributor-one: "נכתב במקור על ידי %s, ועודכן על ידי <a href=\"%s\">אדם נוסף אחד</a>"
+  contributor-other: "נכתב במקור על ידי %s, ועודכן על ידי <a href=\"%s\">%d א·נשים</a>."
+  translatedBy-one: "תורגם על ידי:"
+  translatedBy-other: "תורגם על ידי:"


### PR DESCRIPTION
Note that this includes only the translated strings, without any added logic to for changing the text direction (Hebrew is written RTL while the Latin script is LTR; see https://en.wikipedia.org/wiki/Bidirectional_text).

This can be solved by setting this globally:

```css
unicode-bidi: plaintext;
text-align: start;
```

It changes the behaviour so that if a paragraph begins with a strongly RTL character (say Hebrew א or the Arabic ا) the whole paragraph is deduced to be RTL, while otherwise it’s deduced to be LTR. This means it has no effect where it’s not wanted (the majority of the content on Learn X in Y Minutes is LTR).

One exception is that the `pre` tag, which should be always kept LTR, like so:
```css
unicode-bidi: initial;
text-align: initial;
```

If you want I can make another pull request that adds this.